### PR TITLE
chore: update ansible-runner to 2.4.2

### DIFF
--- a/ansible-ee-minimal/Dockerfile
+++ b/ansible-ee-minimal/Dockerfile
@@ -3,7 +3,7 @@ ARG PYCMD="/opt/venv/bin/python3"
 ARG PKGMGR_PRESERVE_CACHE=""
 ARG ANSIBLE_GALAXY_CLI_COLLECTION_OPTS="--pre"
 ARG ANSIBLE_GALAXY_CLI_ROLE_OPTS=""
-ARG ANSIBLE_INSTALL_REFS="ansible-core==2.17.14 ansible-runner==2.4.1"
+ARG ANSIBLE_INSTALL_REFS="ansible-core==2.17.14 ansible-runner==2.4.2"
 ARG PKGMGR="/usr/bin/apt-get"
 
 # Base build stage

--- a/ansible-ee-minimal/execution-environment.yml
+++ b/ansible-ee-minimal/execution-environment.yml
@@ -16,7 +16,7 @@ dependencies:
   ansible_core:
     package_pip: ansible-core==2.17.14
   ansible_runner:
-    package_pip: ansible-runner==2.4.1
+    package_pip: ansible-runner==2.4.2
   python_interpreter:
     python_path: "/opt/venv/bin/python3"
   galaxy:

--- a/ansible-ee-minimal/execution-environment.yml
+++ b/ansible-ee-minimal/execution-environment.yml
@@ -28,6 +28,7 @@ dependencies:
   system:
     - curl
     - jq
+    - less
     - ssh
     - sshpass
 


### PR DESCRIPTION
Dans le TP 16.2.2 de ansible avancé, il manque less pour faire fonctionner la commande ansible-navigator config dump --only-changed